### PR TITLE
Update to v1.4.4

### DIFF
--- a/Editor/SunaoShaderGUI.cs
+++ b/Editor/SunaoShaderGUI.cs
@@ -47,6 +47,8 @@ namespace SunaoShader {
 		MaterialProperty DecalRotation;
 		MaterialProperty DecalMode;
 		MaterialProperty DecalMirror;
+		MaterialProperty DecalBright;
+		MaterialProperty DecalEmission;
 		MaterialProperty DecalScrollX;
 		MaterialProperty DecalScrollY;
 		MaterialProperty DecalAnimation;
@@ -160,6 +162,7 @@ namespace SunaoShader {
 
 		MaterialProperty Culling;
 		MaterialProperty EnableZWrite;
+		MaterialProperty IgnoreProjector;
 		MaterialProperty DirectionalLight;
 		MaterialProperty SHLight;
 		MaterialProperty PointLight;
@@ -191,7 +194,7 @@ namespace SunaoShader {
 
 		int     Version_H         = 1;
 		int     Version_M         = 4;
-		int     Version_L         = 2;
+		int     Version_L         = 4;
 
 		int     VersionC          = 0;
 		int     VersionM          = 0;
@@ -275,6 +278,8 @@ namespace SunaoShader {
 			DecalRotation     = FindProperty("_DecalRotation"     , Prop , false);
 			DecalMode         = FindProperty("_DecalMode"         , Prop , false);
 			DecalMirror       = FindProperty("_DecalMirror"       , Prop , false);
+			DecalBright       = FindProperty("_DecalBright"       , Prop , false);
+			DecalEmission     = FindProperty("_DecalEmission"     , Prop , false);
 			DecalScrollX      = FindProperty("_DecalScrollX"      , Prop , false);
 			DecalScrollY      = FindProperty("_DecalScrollY"      , Prop , false);
 			DecalAnimation    = FindProperty("_DecalAnimation"    , Prop , false);
@@ -389,6 +394,7 @@ namespace SunaoShader {
 
 			Culling           = FindProperty("_Culling"           , Prop , false);
 			EnableZWrite      = FindProperty("_EnableZWrite"      , Prop , false);
+			IgnoreProjector   = FindProperty("_IgnoreProjector"   , Prop , false);
 			DirectionalLight  = FindProperty("_DirectionalLight"  , Prop , false);
 			SHLight           = FindProperty("_SHLight"           , Prop , false);
 			PointLight        = FindProperty("_PointLight"        , Prop , false);
@@ -553,6 +559,10 @@ namespace SunaoShader {
 							mat.SetInt("_DecalFO" , 1);
 
 							ME.ShaderProperty(DecalMode        , new GUIContent("Decal Mode"       ));
+							if ((int)DecalMode.floatValue == 3) ME.ShaderProperty(DecalBright   , new GUIContent("Brightness Offset" ));
+							if ((int)DecalMode.floatValue == 4) ME.ShaderProperty(DecalEmission , new GUIContent("Emission Intensity"));
+							if ((int)DecalMode.floatValue == 5) ME.ShaderProperty(DecalEmission , new GUIContent("Emission Intensity"));
+
 							ME.ShaderProperty(DecalMirror      , new GUIContent("Decal Mirror Mode"));
 
 							ME.ShaderProperty(DecalScrollX     , new GUIContent("Scroll X"         ));
@@ -584,8 +594,8 @@ namespace SunaoShader {
 				using (new EditorGUILayout.VerticalScope("box")) {
 
 					ME.ShaderProperty(StencilNumb , new GUIContent("Stencil Number"));
-					if (mat.GetInt("_StencilNumb") <   0) mat.SetInt("_StencilNumb" ,   0);
-					if (mat.GetInt("_StencilNumb") > 255) mat.SetInt("_StencilNumb" , 255);
+					if ((int)StencilNumb.floatValue <   0) mat.SetInt("_StencilNumb" ,   0);
+					if ((int)StencilNumb.floatValue > 255) mat.SetInt("_StencilNumb" , 255);
 	
 					if (Shader_StencilRW) {
 						ME.ShaderProperty(StencilCompMode , new GUIContent("Stencil Compare Mode"));
@@ -971,18 +981,18 @@ namespace SunaoShader {
 
 					using (new EditorGUILayout.VerticalScope("box")) {
 
-						GUILayout.Label("Culling Mode" , EditorStyles.boldLabel);
+						GUILayout.Label("Shader Modes" , EditorStyles.boldLabel);
 
-						ME.ShaderProperty(Culling , new GUIContent("Culling Mode"));
-
-					}
-
-					using (new EditorGUILayout.VerticalScope("box")) {
-
-						GUILayout.Label("Z Write"      , EditorStyles.boldLabel);
-
-						ME.ShaderProperty(EnableZWrite , new GUIContent("Enable Z Write"));
-
+						ME.ShaderProperty(Culling         , new GUIContent("Culling Mode"    ));
+						ME.ShaderProperty(EnableZWrite    , new GUIContent("Enable Z Write"  ));
+						/*  うまく動かんっぽい。Unityの仕様？
+						ME.ShaderProperty(IgnoreProjector , new GUIContent("Ignore Projector"));
+						if (IgnoreProjector.floatValue >= 0.5f) {
+							mat.SetOverrideTag("IgnoreProjector", "True" );
+						} else {
+							mat.SetOverrideTag("IgnoreProjector", "False");
+						}
+						*/
 					}
 
 					using (new EditorGUILayout.VerticalScope("box")) {

--- a/Shader/Cginc/SunaoShader_Core.cginc
+++ b/Shader/Cginc/SunaoShader_Core.cginc
@@ -48,6 +48,8 @@
 	uniform float     _DecalRotation;
 	uniform uint      _DecalMode;
 	uniform uint      _DecalMirror;
+	uniform float     _DecalEmission;
+	uniform float     _DecalBright;
 	uniform float     _DecalScrollX;
 	uniform float     _DecalScrollY;
 	uniform float     _DecalAnimation;
@@ -193,6 +195,7 @@ struct VIN {
 struct VOUT {
 
 	float4 pos     : SV_POSITION;
+	float4 vertex  : VERTEX;
 	float2 uv      : TEXCOORD0;
 	float4 uvanm   : TEXCOORD1;
 	float4 decal   : TEXCOORD2;
@@ -202,18 +205,16 @@ struct VOUT {
 	float3 color   : COLOR0;
 	float4 tangent : TANGENT;
 	float3 ldir    : LIGHTDIR0;
-	float3 view    : TEXCOORD5;
-	float4 toon    : TEXCOORD6;
-	float3 tanW    : TEXCOORD7;
-	float3 tanB    : TEXCOORD8;
-	float3 matcapv : TEXCOORD9;
-	float3 matcaph : TEXCOORD10;
-	float4 euv     : TEXCOORD11;
-	float3 eprm    : TEXCOORD12;
-	float4 peuv    : TEXCOORD13;
-	float2 pduv    : TEXCOORD14;
-	float3 peprm   : TEXCOORD15;
-	float3 pview   : TEXCOORD16;
+	float4 toon    : TEXCOORD5;
+	float3 tanW    : TEXCOORD6;
+	float3 tanB    : TEXCOORD7;
+	float3 vfront  : TEXCOORD8;
+	float4 euv     : TEXCOORD9;
+	float3 eprm    : TEXCOORD10;
+	float4 peuv    : TEXCOORD11;
+	float2 pduv    : TEXCOORD12;
+	float3 peprm   : TEXCOORD13;
+	float3 pview   : TEXCOORD14;
 
 	#ifdef PASS_FB
 		float3 shdir   : LIGHTDIR1;
@@ -222,13 +223,13 @@ struct VOUT {
 		float4 vldirX  : LIGHTDIR2;
 		float4 vldirY  : LIGHTDIR3;
 		float4 vldirZ  : LIGHTDIR4;
-		float4 vlcorr  : TEXCOORD17;
-		float4 vlatn   : TEXCOORD18;
+		float4 vlcorr  : TEXCOORD15;
+		float4 vlatn   : TEXCOORD16;
 	#endif
 
-	UNITY_FOG_COORDS(19)
+	UNITY_FOG_COORDS(17)
 	#ifdef PASS_FA
-		LIGHTING_COORDS(20 , 21)
+		LIGHTING_COORDS(18 , 19)
 	#endif
 
 };

--- a/Shader/Cginc/SunaoShader_Frag.cginc
+++ b/Shader/Cginc/SunaoShader_Frag.cginc
@@ -14,6 +14,11 @@
 #endif
 
 float4 frag (FRAG_ARGS) : COLOR {
+//----ワールド座標
+	float3 WorldPos     = mul(unity_ObjectToWorld , IN.vertex).xyz;
+
+//----カメラ視点方向
+	float3 View         = normalize(_WorldSpaceCameraPos - WorldPos);
 
 //-------------------------------------メインカラー
 	float4 OUT          = float4(0.0f , 0.0f , 0.0f , 1.0f);
@@ -32,9 +37,9 @@ float4 frag (FRAG_ARGS) : COLOR {
 	       Color        = Color * _Color.rgb * _Bright * IN.color;
 
 //----デカール
-	if (_DecalEnable) {
+	float4 DecalColor   = float4(0.0f , 0.0f , 0.0f , 1.0f);
 
-		float4   DecalColor    = float4(0.0f , 0.0f , 0.0f , 1.0f);
+	if (_DecalEnable) {
 
 		float2   DecalUV       = (float2)0.0f;
 		float2x2 DecalRot      = float2x2(IN.decal.z, -IN.decal.w, IN.decal.w, IN.decal.z);
@@ -69,27 +74,40 @@ float4 frag (FRAG_ARGS) : COLOR {
 		if (_DecalMirror == 3) DecalColor.a = DecalColor.a *         saturate(IN.tangent.w);
 
 		#ifdef TRANSPARENT
-			if (_DecalMode == 0) {
+			if ((_DecalMode == 0) | (_DecalMode == 5)) {
 				Color        = lerp(Color , lerp(DecalColor.rgb , Color , OUT.a) , DecalColor.a);
 			}
-			if (_DecalMode == 1) {
+			if  (_DecalMode == 1) {
 				Color        = lerp(Color ,                       Color * OUT.a  , DecalColor.a);
 				DecalColor.a = MonoColor(DecalColor.rgb) * DecalColor.a;
 			}
-			if (_DecalMode == 2) {
-				DecalColor.a = (1.0f - MonoColor(DecalColor.rgb)) * DecalColor.a;
+			if ((_DecalMode == 2) | (_DecalMode == 3)) {
+				DecalColor.a = DecalColor.a * OUT.a;
+			}
+			if  (_DecalMode == 4) {
+				DecalColor.a = MonoColor(DecalColor.rgb) * DecalColor.a * _DecalEmission;
 			}
 		#endif
 
 		         OUT.a         = max(OUT.a , DecalColor.a);
 
-		if (_DecalMode == 0) Color = lerp(Color ,          DecalColor.rgb , DecalColor.a);
-		if (_DecalMode == 1) Color = saturate(    Color  + DecalColor.rgb * DecalColor.a);
-		if (_DecalMode == 2) Color = lerp(Color , Color  * DecalColor.rgb , DecalColor.a);
-		if (_DecalMode == 3) {
-			float DecalMixCol = max(Color.r , max(Color.g , Color.b));
+		if ((_DecalMode == 0) | (_DecalMode == 5)) {
+			Color = lerp(Color ,          DecalColor.rgb , DecalColor.a);
+		}
+		if  (_DecalMode == 1) {
+			Color = saturate(    Color  + DecalColor.rgb * DecalColor.a);
+		}
+		if  (_DecalMode == 2) {
+			Color = lerp(Color , Color  * DecalColor.rgb , DecalColor.a);
+		}
+		if  (_DecalMode == 3) {
+			float DecalMixCol = saturate(max(Color.r , max(Color.g , Color.b)) + _DecalBright);
 			Color = lerp(Color , DecalMixCol * DecalColor.rgb , DecalColor.a);
 		}
+		if ((_DecalMode == 4) | (_DecalMode == 5)) {
+			DecalColor.rgb = DecalColor.rgb * DecalColor.a;
+		}
+
 	}
 
 //----オクルージョン
@@ -143,16 +161,35 @@ float4 frag (FRAG_ARGS) : COLOR {
 	       ShadeColor   = lerp(ShadeColor , _CustomShadeColor.rgb , _CustomShadeColor.a);
 
 //-------------------------------------ライティング
+	float3 LightBase    = (float3)0.0f;
+
 	#ifdef PASS_FB
-		float3 LightBase    = _LightColor0 * _DirectionalLight;
-		float3 VLight0      = unity_LightColor[0].rgb * IN.vlatn.x * 0.6f;
-		float3 VLight1      = unity_LightColor[1].rgb * IN.vlatn.y * 0.6f;
-		float3 VLight2      = unity_LightColor[2].rgb * IN.vlatn.z * 0.6f;
-		float3 VLight3      = unity_LightColor[3].rgb * IN.vlatn.w * 0.6f;
-		float3 VLightBase   = saturate(VLight0 + VLight1 + VLight2 + VLight3);
+		       LightBase    = _LightColor0 * _DirectionalLight;
+		float3 VLight0      = unity_LightColor[0].rgb * IN.vlatn.x;
+		float3 VLight1      = unity_LightColor[1].rgb * IN.vlatn.y;
+		float3 VLight2      = unity_LightColor[2].rgb * IN.vlatn.z;
+		float3 VLight3      = unity_LightColor[3].rgb * IN.vlatn.w;
+		float3 VLightBase   = (float3)0.0f;
+
+		if (_BlendOperation == 4) {
+			   VLightBase   = saturate((VLight0 + VLight1 + VLight2 + VLight3) * 0.8f);
+		} else {
+			   VLightBase   = saturate((VLight0 + VLight1 + VLight2 + VLight3) * 0.6f);
+		}
 	#endif
 	#ifdef PASS_FA
-		float3 LightBase    = _LightColor0 * LIGHT_ATTENUATION(IN) * _PointLight * 0.6f;
+		       LightBase    = LIGHT_ATTENUATION(IN);
+		//思うようにならなかったので没。Sunao Shader 2でなんとかするかも
+		//if (_ToonEnable) {
+		//	   LightBase    = ToonCalc(LIGHT_ATTENUATION(IN) , IN.toon);
+		//	   LightBase    = lerp(LightBase , LIGHT_ATTENUATION(IN) , 0.15f);
+		//}
+			   LightBase   *= _LightColor0 * _PointLight;
+		if (_BlendOperation == 4) {
+			   LightBase   *= 0.8f;
+		} else {
+			   LightBase   *= 0.6f;
+		}
 	#endif
 
 //----モノクロライティング
@@ -195,8 +232,8 @@ float4 frag (FRAG_ARGS) : COLOR {
 		       MaxLight   = max(MaxLight , Lighting.r);
 		       MaxLight   = max(MaxLight , Lighting.g);
 		       MaxLight   = max(MaxLight , Lighting.b);
-
-		Lighting = saturate(Lighting / MaxLight);
+		       MaxLight   = min(MaxLight , 1.5f);
+		       Lighting   = saturate(Lighting / MaxLight);
 	}
 
 //-------------------------------------エミッション
@@ -224,7 +261,7 @@ float4 frag (FRAG_ARGS) : COLOR {
 		#ifdef SPARKLES
 			if (_SparkleEnable) {
 				float4 p = tex2D(_SparkleParameterMap, IN.euv.xy);
-				float SparkleValue = Sparkles(IN.view, float3(IN.euv.xy, 1.0f),
+				float SparkleValue = Sparkles(View, float3(IN.euv.xy, 1.0f),
 				                              _SparkleDensity * p.r, _SparkleSmoothness * p.g, _SparkleFineness * p.b,
 				                              _SparkleAngularBlink, _SparkleTimeBlink);
 				Emission *= saturate(SparkleValue);
@@ -274,12 +311,12 @@ float4 frag (FRAG_ARGS) : COLOR {
 		       SpecularMask = tex2D(_MetallicGlossMap , SubUV).rgb;
 		       SpecularMask = lerp(1.0f , SpecularMask , _SpecularMask);
 
-		float3 RLSpecular   = SpecularCalc(Normal , IN.ldir , IN.view , Smoothness) * LightBase;
+		float3 RLSpecular   = SpecularCalc(Normal , IN.ldir , View , Smoothness) * LightBase;
 
 		#ifdef PASS_FB
 			float3 SHSpecular   = (float3)0.0f;
 			if (_SpecularSH) {
-			       SHSpecular   = SpecularCalc(Normal , IN.shdir , IN.view , Smoothness) * IN.shmax;
+			       SHSpecular   = SpecularCalc(Normal , IN.shdir , View , Smoothness) * IN.shmax;
 			}
 			       Specular     = (RLSpecular + SHSpecular) * _Specular * ((Smoothness * Smoothness * Smoothness) + 0.25f);
 		#endif
@@ -291,7 +328,7 @@ float4 frag (FRAG_ARGS) : COLOR {
 		       ReflectMask  = tex2D(_MetallicGlossMap , SubUV).rgb;
 
 		#ifdef PASS_FB
-			       Reflection   = ReflectionCalc(Normal , IN.view , Smoothness);
+			       Reflection   = ReflectionCalc(WorldPos , Normal , View , Smoothness);
 
 			if (_ReflectLit == 1) Reflection *= saturate(LightBase + VLightBase);
 			if (_ReflectLit == 2) Reflection *= saturate(IN.shmax);
@@ -299,7 +336,7 @@ float4 frag (FRAG_ARGS) : COLOR {
 		#endif
 		#ifdef PASS_FA
 			if ((_ReflectLit == 1) || (_ReflectLit == 3)) {
-			       Reflection   = ReflectionCalc(Normal , IN.view , Smoothness);
+			       Reflection   = ReflectionCalc(WorldPos , Normal , View , Smoothness);
 				   Reflection  *= saturate(LightBase);
 			}
 		#endif
@@ -310,8 +347,11 @@ float4 frag (FRAG_ARGS) : COLOR {
 		       MatCapSmooth = lerp(MatCapSmooth , tex2D(_MetallicGlossMap , SubUV).a , _MatCapMaskEnable);
 		       MatCapMask   = lerp(MatCapMask   , ReflectMask                        , _MatCapMaskEnable);
 
+		float3 MatCapV      = normalize(IN.vfront - View * dot(View, IN.vfront));
+		float3 MatCapH      = normalize(cross(View , MatCapV));
+
 		#ifdef PASS_FB
-			float2 MatCapUV     = float2(dot(IN.matcaph , Normal), dot(IN.matcapv , Normal)) * 0.5f + 0.5f;
+			float2 MatCapUV     = float2(dot(MatCapH , Normal), dot(MatCapV , Normal)) * 0.5f + 0.5f;
 			       MatCapture   = tex2Dbias(_MatCap , float4(MatCapUV , 0.0f , 3.0f * (1.0f - MatCapSmooth))).rgb * _MatCapStrength;
 
 			if (_MatCapLit == 1) MatCapture *= saturate(LightBase + VLightBase);
@@ -320,7 +360,7 @@ float4 frag (FRAG_ARGS) : COLOR {
 		#endif
 		#ifdef PASS_FA
 			if ((_MatCapLit  == 1) || (_MatCapLit  == 3)) {
-				float2 MatCapUV    = float2(dot(IN.matcaph , Normal), dot(IN.matcapv , Normal)) * 0.5f + 0.5f;
+				float2 MatCapUV    = float2(dot(MatCapH , Normal), dot(MatCapV , Normal)) * 0.5f + 0.5f;
 				       MatCapture  = tex2Dbias(_MatCap , float4(MatCapUV , 0.0f , 3.0f * (1.0f - MatCapSmooth))).rgb * _MatCapStrength;
 				       MatCapture *= saturate(LightBase);
 			}
@@ -345,7 +385,7 @@ float4 frag (FRAG_ARGS) : COLOR {
 	float3 RimLight = (float3)0.0f;
 	#ifdef PASS_FB
 		if (_RimLitEnable) {
-			       RimLight  = RimLightCalc(Normal , IN.view , _RimLit , _RimLitGradient);
+			       RimLight  = RimLightCalc(Normal , View , _RimLit , _RimLitGradient);
 			       RimLight *= _RimLitColor.rgb * _RimLitColor.a * SAMPLE_TEX2D_SAMPLER(_RimLitMask , _MainTex , SubUV).rgb;
 			if (_RimLitLighthing) RimLight *= saturate(LightBase + IN.shmax + VLightBase);
 			if (_RimLitTexColor ) RimLight *= Color;
@@ -353,7 +393,7 @@ float4 frag (FRAG_ARGS) : COLOR {
 	#endif
 	#ifdef PASS_FA
 		if (_RimLitEnable && _RimLitLighthing) {
-			       RimLight  = RimLightCalc(Normal , IN.view , _RimLit , _RimLitGradient);
+			       RimLight  = RimLightCalc(Normal , View , _RimLit , _RimLitGradient);
 			       RimLight *= _RimLitColor.rgb * _RimLitColor.a * SAMPLE_TEX2D_SAMPLER(_RimLitMask , _MainTex , SubUV).rgb;
 			       RimLight *= saturate(LightBase);
 			if (_RimLitTexColor ) RimLight *= Color;
@@ -373,6 +413,14 @@ float4 frag (FRAG_ARGS) : COLOR {
 		if (_RimLitMode == 1) OUT.rgb *= RimLight;
 		if (_RimLitMode == 2) OUT.rgb  = saturate(OUT.rgb - RimLight);
 	}
+
+//----デカールエミッション混合
+	#ifdef PASS_FB
+		if (_DecalEnable) {
+			if (_DecalMode == 4) OUT.rgb += DecalColor.rgb * _DecalEmission;
+			if (_DecalMode == 5) OUT.rgb += DecalColor.rgb * _DecalEmission;
+		}
+	#endif
 
 //----エミッション混合
 	if (EmissionFlag) {
@@ -474,7 +522,10 @@ float4 frag (FRAG_ARGS) : COLOR {
 //----SrcAlphaの代用
 	#ifdef TRANSPARENT
 		#ifdef PASS_FA
-			if (_BlendOperation == 4) OUT.rgb *= OUT.a;
+			if (_BlendOperation == 4) {
+				OUT.a    = 1.055f * pow(OUT.a , 0.41666667f) - 0.055f;
+				OUT.rgb *= OUT.a;
+			}
 		#endif
 	#endif
 

--- a/Shader/Cginc/SunaoShader_Function.cginc
+++ b/Shader/Cginc/SunaoShader_Function.cginc
@@ -98,7 +98,8 @@ float  ToonCalc(float diffuse , float4 toon) {
 	float Diffuse;
 	float Gradient;
 
-	Gradient = frac((max(diffuse , 0.0000001f) + toon.z) * toon.x) - 0.5f;
+	diffuse  = max(diffuse , 0.000001f);
+	Gradient = frac((diffuse + toon.z - 0.0000001f) * toon.x) - 0.5f;
 	Gradient = saturate(Gradient * toon.w + 0.5f) + 0.5f;
 	Gradient = (frac(Gradient) - 0.5f) * toon.y;
 	Diffuse  = floor(diffuse * toon.x) * toon.y + Gradient;
@@ -126,11 +127,20 @@ float3 SpecularCalc(float3 normal , float3 ldir , float3 view , float scale) {
 }
 
 //-------------------------------------環境マッピングの計算
-float3 ReflectionCalc(float3 normal , float3 view , float scale) {
-	float3 dir = reflect(-view , normal);
+float3 ReflectionCalc(float3 wpos , float3 normal , float3 view , float scale) {
+	float3 dir   = reflect(-view , normal);
 	float3 ocol;
 	float3 refl0;
 	float3 refl1;
+
+	#if UNITY_SPECCUBE_BOX_PROJECTION
+		if (unity_SpecCube0_ProbePosition.w > 0) {
+			float3 rbox   = ((dir > 0 ? unity_SpecCube0_BoxMax.xyz : unity_SpecCube0_BoxMin.xyz) - wpos) / dir;
+			float  rsize  = min(min(rbox.x, rbox.y), rbox.z);
+			       dir    = dir * rsize + (wpos - unity_SpecCube0_ProbePosition);
+		}
+	#endif
+
 	refl0 = DecodeHDR(UNITY_SAMPLE_TEXCUBE_LOD        (unity_SpecCube0                  , dir, (1.0f - scale) * 7.0f) , unity_SpecCube0_HDR);
 	refl1 = DecodeHDR(UNITY_SAMPLE_TEXCUBE_SAMPLER_LOD(unity_SpecCube1, unity_SpecCube0 , dir, (1.0f - scale) * 7.0f) , unity_SpecCube1_HDR);
 	ocol  = lerp(refl1 , refl0 , unity_SpecCube0_BoxMin.w);

--- a/Shader/Cginc/SunaoShader_SC.cginc
+++ b/Shader/Cginc/SunaoShader_SC.cginc
@@ -1,0 +1,101 @@
+//--------------------------------------------------------------
+//              Sunao Shader ShadowCaster
+//                      Copyright (c) 2021 揚茄子研究所
+//--------------------------------------------------------------
+
+
+//-------------------------------------Include
+
+	#include "UnityCG.cginc"
+	#include "Simplex3D.cginc"
+	#include "SunaoShader_Function.cginc"
+
+//-------------------------------------変数宣言
+
+	uniform sampler2D _MainTex;
+	uniform float4    _MainTex_ST;
+	uniform float4    _Color;
+	uniform float     _Cutout;
+	uniform float     _Alpha;
+	uniform sampler2D _AlphaMask;
+	uniform float     _AlphaMaskStrength;
+	uniform float     _UVScrollX;
+	uniform float     _UVScrollY;
+	uniform float     _UVAnimation;
+	uniform uint      _UVAnimX;
+	uniform uint      _UVAnimY;
+	uniform bool      _UVAnimOtherTex;
+
+//-------------------------------------頂点シェーダ入力構造体
+
+struct VIN {
+	float4 vertex  : POSITION;
+	float2 uv      : TEXCOORD0;
+};
+
+//-------------------------------------頂点シェーダ出力構造体
+
+struct VOUT {
+	float2 uv      : TEXCOORD0;
+	float4 uvanm   : TEXCOORD1;
+
+	V2F_SHADOW_CASTER;
+};
+
+//-------------------------------------頂点シェーダ
+
+VOUT vert (VIN v) {
+
+	VOUT o;
+
+//-------------------------------------頂点座標変換
+	o.pos = UnityObjectToClipPos(v.vertex);
+
+//-------------------------------------UV
+	o.uv      = (v.uv * _MainTex_ST.xy) + _MainTex_ST.zw;
+
+//-------------------------------------UVアニメーション
+	o.uvanm   = float4(0.0f , 0.0f , 1.0f , 1.0f);
+
+	if (_UVAnimation > 0.0f) {
+		o.uvanm.zw  = 1.0f / float2(_UVAnimX , _UVAnimY);
+
+		float2 UVAnimSpeed    = _UVAnimation * _UVAnimY;
+		       UVAnimSpeed.y *= -o.uvanm.w;
+
+		o.uvanm.xy += floor(frac(UVAnimSpeed * _Time.y) * float2(_UVAnimX , _UVAnimY));
+	}
+
+	TRANSFER_SHADOW_CASTER(o)
+
+	return o;
+}
+
+//-------------------------------------フラグメントシェーダ
+
+float4 frag (VOUT IN) : COLOR {
+
+	float4 OUT          = (float4)1.0f;
+
+	#if defined(TRANSPARENT) || defined(CUTOUT)
+		float2 MainUV       = (IN.uv + IN.uvanm.xy) * IN.uvanm.zw;
+		       MainUV      += float2(_UVScrollX , _UVScrollY) * _Time.y;
+		float2 SubUV        = IN.uv;
+		if (_UVAnimOtherTex) SubUV = MainUV;
+
+	           OUT.a        = saturate(tex2D(_MainTex , MainUV).a * _Color.a * _Alpha);
+	           OUT.a       *= lerp(1.0f , MonoColor(tex2D(_AlphaMask  , SubUV).rgb) , _AlphaMaskStrength);
+	#endif
+
+	#ifdef TRANSPARENT
+		clip(OUT.a - 0.3);
+	#endif
+
+	#ifdef CUTOUT
+		clip(OUT.a - _Cutout);
+	#endif
+
+	SHADOW_CASTER_FRAGMENT(IN)
+
+	return OUT;
+}

--- a/Shader/Sunao_Shader_Cutout.shader
+++ b/Shader/Sunao_Shader_Cutout.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/Cutout" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/Cutout" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/Cutout" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/Cutout" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "TransparentCutout"
 			"Queue"           = "AlphaTest"
 		}
@@ -400,6 +406,7 @@ Shader "Sunao Shader/Cutout" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -410,6 +417,7 @@ Shader "Sunao Shader/Cutout" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define CUTOUT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 

--- a/Shader/Sunao_Shader_Cutout_SO.shader
+++ b/Shader/Sunao_Shader_Cutout_SO.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/[Stencil Outline]/Cutout" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/[Stencil Outline]/Cutout" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/[Stencil Outline]/Cutout" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/[Stencil Outline]/Cutout" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "TransparentCutout"
 			"Queue"           = "AlphaTest"
 		}
@@ -416,6 +422,7 @@ Shader "Sunao Shader/[Stencil Outline]/Cutout" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -426,6 +433,7 @@ Shader "Sunao Shader/[Stencil Outline]/Cutout" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define CUTOUT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 

--- a/Shader/Sunao_Shader_Opaque.shader
+++ b/Shader/Sunao_Shader_Opaque.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/Opaque" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/Opaque" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/Opaque" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/Opaque" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Opaque"
 			"Queue"           = "Geometry"
 		}

--- a/Shader/Sunao_Shader_Opaque_DoubleSided.shader
+++ b/Shader/Sunao_Shader_Opaque_DoubleSided.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/Opaque Double Sided" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/Opaque Double Sided" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/Opaque Double Sided" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/Opaque Double Sided" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Opaque"
 			"Queue"           = "Geometry"
 		}

--- a/Shader/Sunao_Shader_Opaque_SO.shader
+++ b/Shader/Sunao_Shader_Opaque_SO.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/[Stencil Outline]/Opaque" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/[Stencil Outline]/Opaque" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/[Stencil Outline]/Opaque" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/[Stencil Outline]/Opaque" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Opaque"
 			"Queue"           = "Geometry"
 		}

--- a/Shader/Sunao_Shader_Opaque_Sparkles.shader
+++ b/Shader/Sunao_Shader_Opaque_Sparkles.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/Opaque Sparkles" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/Opaque Sparkles" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/Opaque Sparkles" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/Opaque Sparkles" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Opaque"
 			"Queue"           = "Geometry"
 		}

--- a/Shader/Sunao_Shader_Stencil_R.shader
+++ b/Shader/Sunao_Shader_Stencil_R.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/[Stencil]/Read" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -230,6 +233,9 @@ Shader "Sunao Shader/[Stencil]/Read" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -269,7 +275,7 @@ Shader "Sunao Shader/[Stencil]/Read" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -280,7 +286,7 @@ Shader "Sunao Shader/[Stencil]/Read" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "TransparentCutout"
 			"Queue"           = "AlphaTest+1"
 		}
@@ -412,6 +418,7 @@ Shader "Sunao Shader/[Stencil]/Read" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -427,6 +434,7 @@ Shader "Sunao Shader/[Stencil]/Read" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define CUTOUT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 

--- a/Shader/Sunao_Shader_Stencil_W.shader
+++ b/Shader/Sunao_Shader_Stencil_W.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/[Stencil]/Write" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -230,6 +233,9 @@ Shader "Sunao Shader/[Stencil]/Write" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -269,7 +275,7 @@ Shader "Sunao Shader/[Stencil]/Write" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -280,7 +286,7 @@ Shader "Sunao Shader/[Stencil]/Write" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "TransparentCutout"
 			"Queue"           = "AlphaTest"
 		}
@@ -417,6 +423,7 @@ Shader "Sunao Shader/[Stencil]/Write" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -427,6 +434,7 @@ Shader "Sunao Shader/[Stencil]/Write" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define CUTOUT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 

--- a/Shader/Sunao_Shader_Transparent.shader
+++ b/Shader/Sunao_Shader_Transparent.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/Transparent" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/Transparent" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/Transparent" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/Transparent" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Transparent"
 			"Queue"           = "Transparent"
 		}
@@ -401,6 +407,7 @@ Shader "Sunao Shader/Transparent" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -411,6 +418,7 @@ Shader "Sunao Shader/Transparent" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define TRANSPARENT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 

--- a/Shader/Sunao_Shader_Transparent_SO.shader
+++ b/Shader/Sunao_Shader_Transparent_SO.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/[Stencil Outline]/Transparent" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/[Stencil Outline]/Transparent" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/[Stencil Outline]/Transparent" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/[Stencil Outline]/Transparent" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Transparent"
 			"Queue"           = "Transparent"
 		}
@@ -418,6 +424,7 @@ Shader "Sunao Shader/[Stencil Outline]/Transparent" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -428,6 +435,7 @@ Shader "Sunao Shader/[Stencil Outline]/Transparent" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define TRANSPARENT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 

--- a/Shader/Sunao_Shader_Transparent_Sparkles.shader
+++ b/Shader/Sunao_Shader_Transparent_Sparkles.shader
@@ -1,5 +1,5 @@
 ﻿//--------------------------------------------------------------
-//              Sunao Shader    Ver 1.4.2
+//              Sunao Shader    Ver 1.4.4
 //
 //                      Copyright (c) 2021 揚茄子研究所
 //                              Twitter : @SUNAO_VRC
@@ -56,10 +56,13 @@ Shader "Sunao Shader/Transparent Sparkles" {
 		_DecalSizeY        ("Size Y"                    , Range( 0.0, 1.0)) = 0.5
 		_DecalRotation     ("Rotation"                  , Range(-180.0, 180.0)) = 0.0
 
-		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3)]
+		[Enum(Override , 0 , Add , 1 , Multiply , 2 , Multiply(Mono) , 3 , Emissive(Add) , 4 , Emissive(Override) , 5)]
 		_DecalMode         ("Decal Mode"                , int) = 0
 		[Enum(Normal , 0 , Fixed , 1 , Mirror1 , 2 , Mirror2 , 3 , Copy(Mirror) , 4 , Copy(Fixed) , 5)]
 		_DecalMirror       ("Decal Mirror Mode"         , int) = 0
+
+		_DecalBright       ("Brightness Offset"         , Range( -1.0,  1.0)) = 0.0
+		_DecalEmission     ("Emission Intensity"        , Range(  0.0, 10.0)) = 1.0
 
 		_DecalScrollX      ("Scroll X"                  , Range(-10.0, 10.0)) = 0.0
 		_DecalScrollY      ("Scroll Y"                  , Range(-10.0, 10.0)) = 0.0
@@ -239,6 +242,9 @@ Shader "Sunao Shader/Transparent Sparkles" {
 		[SToggle]
 		_EnableZWrite      ("Enable Z Write"            , int) = 1
 
+		//[SToggle]
+		//_IgnoreProjector   ("Ignore Projector"          , int) = 0
+
 		_DirectionalLight  ("Directional Light"         , Range( 0.0,  2.0)) = 1.0
 		_SHLight           ("SH Light"                  , Range( 0.0,  2.0)) = 1.0
 		_PointLight        ("Point Light"               , Range( 0.0,  2.0)) = 1.0
@@ -278,7 +284,7 @@ Shader "Sunao Shader/Transparent Sparkles" {
 
 		[HideInInspector] _VersionH        ("Version H"         , int) = 1
 		[HideInInspector] _VersionM        ("Version M"         , int) = 4
-		[HideInInspector] _VersionL        ("Version L"         , int) = 2
+		[HideInInspector] _VersionL        ("Version L"         , int) = 4
 
 	}
 
@@ -289,7 +295,7 @@ Shader "Sunao Shader/Transparent Sparkles" {
 		LOD 0
 
 		Tags {
-			"IgnoreProjector" = "True"
+			"IgnoreProjector" = "False"
 			"RenderType"      = "Transparent"
 			"Queue"           = "Transparent"
 		}
@@ -405,6 +411,7 @@ Shader "Sunao Shader/Transparent Sparkles" {
 				"LightMode" = "ShadowCaster"
 			}
 
+			Cull [_Culling]
 			ZWrite On
 			ZTest LEqual
 
@@ -415,6 +422,7 @@ Shader "Sunao Shader/Transparent Sparkles" {
 			#pragma target 4.5
 
 			#define PASS_SC
+			#define TRANSPARENT
 
 			#include "./cginc/SunaoShader_SC.cginc"
 


### PR DESCRIPTION
Hello,

I tried to apply an update to Sunao Shader v1.4.4.

This update was applied by:
- Creating a differential patch from Sunao Shader v1.4.2 to LamePatchForSunaoShader 1.4.2, ( 83dc8ca1a8d0f6d392a4913bbc32784ebed2c915 932fff46915541505ee299c4484fd3f312c54e0e  ), upgrading to Sunao Shader 1.4.4 ( c9e060a4c30e31c7ee98f4fe0f35a8b935dec2c0 0daa10b712d007f385533ce3672c9d018b984d41 ), **then applying that patch on top of Sunao Shader 1.4.4 233753126b656e6e27937ac3648f2ee8e01078dd 06a896cdab42240e41294afbd106d341bde70b8e )**
- Add #include Simplex3D in SunaoShader_SC  ( 6c0ec712c385b4b4eb248624c32d48d2306293a1 )
- Apply correction from IN.view to View ( 07b65b3ff5dcf75abc336cc7ca288101c4a80015 )

All of the above were rebased into this pull request.

I am hoping that the contents of this patch is correct.

---

こんにちは。

Sunao Shader v1.4.4のアップデートを適用しようとしました。

このアップデートの適用方法は

- Sunao Shader v1.4.2 から LamePatchForSunaoShader 1.4.2 への差分パッチを作成し ( 83dc8ca 932fff4 )、Sunao Shader 1.4.4 にアップグレードし ( c9e060a 0daa10b )、**そのパッチを Sunao Shader 1.4.4 の上に適用する ( 2337531 06a896c )**
- SunaoShader_SCに#include Simplex3Dを追加 ( 6c0ec71 )
- IN.viewからViewへの補正を適用 ( 07b65b3 )

以上の内容をすべてこのプルリクエストにリベースしました。

このパッチの内容が正しいことを期待しています。
